### PR TITLE
Fix char issue and compiler warnings

### DIFF
--- a/ML-PACE/ace_abstract_basis.h
+++ b/ML-PACE/ace_abstract_basis.h
@@ -287,13 +287,13 @@ public:
      * Copy dynamic memory from src. Must be override and extended in derived classes!
      * @param src source object to copy from
      */
-    virtual void _copy_dynamic_memory(const ACEAbstractBasisSet &src);
+    void _copy_dynamic_memory(const ACEAbstractBasisSet &src);
 
     /**
      * Copy scalar values from src. Must be override and extended in derived classes!
      * @param src source object to copy from
      */
-    virtual void _copy_scalar_memory(const ACEAbstractBasisSet &src);
+    void _copy_scalar_memory(const ACEAbstractBasisSet &src);
 
     virtual vector<DOUBLE_TYPE> get_all_coeffs() const = 0;
 

--- a/ML-PACE/ace_types.h
+++ b/ML-PACE/ace_types.h
@@ -30,7 +30,7 @@
 #ifndef ACE_TYPES_H
 #define ACE_TYPES_H
 
-typedef char RANK_TYPE;
+typedef signed char RANK_TYPE;
 typedef int SPECIES_TYPE;
 typedef short int NS_TYPE;
 typedef short int LS_TYPE;


### PR DESCRIPTION
- Fix hang on Power9 because it assumes `char` is unsigned.
- Also fix some compiler warnings: 

```
../../lib/pace/src/ML-PACE/ace_flatten_basis.h(122): warning: function "ACEAbstractBasisSet::_copy_dynamic_memory(const ACEAbstractBasisSet &)" is hidden by "ACEFlattenBasisSet::_copy_dynamic_memory" -- virtual function override intended?

../../lib/pace/src/ML-PACE/ace_flatten_basis.h(116): warning: function "ACEAbstractBasisSet::_copy_scalar_memory(const ACEAbstractBasisSet &)" is hidden by "ACEFlattenBasisSet::_copy_scalar_memory" -- virtual function override intended?

../../lib/pace/src/ML-PACE/ace_c_basis.h(91): warning: function "ACEAbstractBasisSet::_copy_dynamic_memory(const ACEAbstractBasisSet &)" is hidden by "ACECTildeBasisSet::_copy_dynamic_memory" -- virtual function override intended?

../../lib/pace/src/ML-PACE/ace_c_basis.h(97): warning: function "ACEAbstractBasisSet::_copy_scalar_memory(const ACEAbstractBasisSet &)" is hidden by "ACECTildeBasisSet::_copy_scalar_memory" -- virtual function override intended?
```