### PR TITLE
Refactor include file handling to require fewer include paths and reduce risk of conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(YAML_CPP_INCLUDE_DIR yaml-cpp/include)
 
 ## cnpy
 set(CNPY_PATH cnpy)
-set(CNPY_INCLUDE_PATH ${CNPY_PATH})
+set(CNPY_INCLUDE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 set(CNPY_SRC ${CNPY_PATH}/cnpy.cpp)
 add_library(cnpy-static STATIC ${CNPY_SRC})
 set_target_properties(cnpy-static PROPERTIES LINKER_LANGUAGE CXX)
@@ -31,11 +31,10 @@ set_target_properties(cnpy-static PROPERTIES LINKER_LANGUAGE CXX)
 ## winger-cpp
 # this is header-only library
 set(WIGNER_PATH wigner-cpp)
-set(WIGNER_INCLUDE_PATH ${WIGNER_PATH}/include/wigner)
+set(WIGNER_INCLUDE_PATH ${WIGNER_PATH}/include)
 
 # ML-PACE includes
-file(GLOB PACE_EVALUATOR_INCLUDE_DIR ML-PACE/ace-evaluator)
-file(GLOB PACE_INCLUDE_DIR ML-PACE/ace)
+file(GLOB PACE_INCLUDE_DIR ML-PACE)
 
 # ML-PACE sources
 file(GLOB PACE_EVALUATOR_SOURCES ML-PACE/ace-evaluator/*.cpp)
@@ -45,6 +44,7 @@ list(FILTER PACE_SOURCES EXCLUDE REGEX pair_pace*.cpp)
 
 add_library(pace STATIC ${PACE_EVALUATOR_SOURCES} ${PACE_SOURCES})
 #set_target_properties(pace PROPERTIES CXX_EXTENSIONS ON OUTPUT_NAME lammps_pace${LAMMPS_MACHINE})
-target_include_directories(pace PUBLIC ${PACE_EVALUATOR_INCLUDE_DIR} ${PACE_INCLUDE_DIR} ${YAML_CPP_INCLUDE_DIR} ${CNPY_INCLUDE_PATH} ${WIGNER_INCLUDE_PATH})
+target_include_directories(pace PUBLIC ${PACE_INCLUDE_DIR} ${YAML_CPP_INCLUDE_DIR})
+target_include_directories(pace PRIVATE ${CNPY_INCLUDE_PATH} ${WIGNER_INCLUDE_PATH})
 target_compile_definitions(pace PUBLIC EXTRA_C_PROJECTIONS) # important for B-projections and extrapolation grade calculations
 target_link_libraries(pace PRIVATE yaml-cpp-pace cnpy-static)

--- a/ML-PACE/ace-evaluator/ace_abstract_basis.cpp
+++ b/ML-PACE/ace-evaluator/ace_abstract_basis.cpp
@@ -27,8 +27,8 @@
 
 // Created by Lysogorskiy Yury on 28.04.2020.
 
-#include "ace_abstract_basis.h"
-#include "ace_radial.h"
+#include "ace-evaluator/ace_abstract_basis.h"
+#include "ace-evaluator/ace_radial.h"
 
 ////embedding function
 ////case nemb = 1 only implementation

--- a/ML-PACE/ace-evaluator/ace_abstract_basis.h
+++ b/ML-PACE/ace-evaluator/ace_abstract_basis.h
@@ -36,11 +36,11 @@
 #include <map>
 #include <tuple>
 
-#include "ace_c_basisfunction.h"
-#include "ace_contigous_array.h"
-#include "ace_radial.h"
-#include "ace_spherical_cart.h"
-#include "ace_types.h"
+#include "ace-evaluator/ace_c_basisfunction.h"
+#include "ace-evaluator/ace_contigous_array.h"
+#include "ace-evaluator/ace_radial.h"
+#include "ace-evaluator/ace_spherical_cart.h"
+#include "ace-evaluator/ace_types.h"
 
 using namespace std;
 

--- a/ML-PACE/ace-evaluator/ace_array2dlm.h
+++ b/ML-PACE/ace-evaluator/ace_array2dlm.h
@@ -35,9 +35,9 @@
 #include <stdexcept>
 #include <string>
 
-#include "ace_arraynd.h"
-#include "ace_contigous_array.h"
-#include "ace_types.h"
+#include "ace-evaluator/ace_arraynd.h"
+#include "ace-evaluator/ace_contigous_array.h"
+#include "ace-evaluator/ace_types.h"
 
 using namespace std;
 

--- a/ML-PACE/ace-evaluator/ace_arraynd.h
+++ b/ML-PACE/ace-evaluator/ace_arraynd.h
@@ -35,7 +35,7 @@
 #include <vector>
 #include <stdexcept>
 
-#include "ace_contigous_array.h"
+#include "ace-evaluator/ace_contigous_array.h"
 
 using namespace std;
 

--- a/ML-PACE/ace-evaluator/ace_c_basis.cpp
+++ b/ML-PACE/ace-evaluator/ace_c_basis.cpp
@@ -28,8 +28,8 @@
 // Created by Yury Lysogorskiy on 1.04.20.
 #include <fstream>
 
-#include "ace_c_basis.h"
-#include "ships_radial.h"
+#include "ace-evaluator/ace_c_basis.h"
+#include "ace-evaluator/ships_radial.h"
 
 using namespace std;
 

--- a/ML-PACE/ace-evaluator/ace_c_basis.h
+++ b/ML-PACE/ace-evaluator/ace_c_basis.h
@@ -30,8 +30,8 @@
 #ifndef ACE_C_BASIS_H
 #define ACE_C_BASIS_H
 
-#include "ace_flatten_basis.h"
-#include "ships_radial.h"
+#include "ace-evaluator/ace_flatten_basis.h"
+#include "ace-evaluator/ships_radial.h"
 
 typedef vector<vector<ACECTildeBasisFunction>> C_tilde_full_basis_vector2d;
 

--- a/ML-PACE/ace-evaluator/ace_c_basisfunction.h
+++ b/ML-PACE/ace-evaluator/ace_c_basisfunction.h
@@ -39,7 +39,7 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "ace_types.h"
+#include "ace-evaluator/ace_types.h"
 
 //macros for copying the member-array from "other" object for C-tilde and B-basis
 #define basis_mem_copy(other, array, size, type) if(other.array) { \

--- a/ML-PACE/ace-evaluator/ace_contigous_array.h
+++ b/ML-PACE/ace-evaluator/ace_contigous_array.h
@@ -32,7 +32,7 @@
 
 #include <string>
 
-#include "ace_types.h"
+#include "ace-evaluator/ace_types.h"
 
 using namespace std;
 

--- a/ML-PACE/ace-evaluator/ace_evaluator.cpp
+++ b/ML-PACE/ace-evaluator/ace_evaluator.cpp
@@ -27,10 +27,10 @@
 
 // Created by Yury Lysogorskiy on 31.01.20.
 
-#include "ace_evaluator.h"
+#include "ace-evaluator/ace_evaluator.h"
 
-#include "ace_abstract_basis.h"
-#include "ace_types.h"
+#include "ace-evaluator/ace_abstract_basis.h"
+#include "ace-evaluator/ace_types.h"
 
 void ACEEvaluator::init(ACEAbstractBasisSet *basis_set) {
     A.init(basis_set->nelements, basis_set->nradmax + 1, basis_set->lmax + 1, "A");

--- a/ML-PACE/ace-evaluator/ace_evaluator.h
+++ b/ML-PACE/ace-evaluator/ace_evaluator.h
@@ -31,13 +31,13 @@
 #ifndef ACE_EVALUATOR_H
 #define ACE_EVALUATOR_H
 
-#include "ace_abstract_basis.h"
-#include "ace_arraynd.h"
-#include "ace_array2dlm.h"
-#include "ace_c_basis.h"
-#include "ace_complex.h"
-#include "ace_timing.h"
-#include "ace_types.h"
+#include "ace-evaluator/ace_abstract_basis.h"
+#include "ace-evaluator/ace_arraynd.h"
+#include "ace-evaluator/ace_array2dlm.h"
+#include "ace-evaluator/ace_c_basis.h"
+#include "ace-evaluator/ace_complex.h"
+#include "ace-evaluator/ace_timing.h"
+#include "ace-evaluator/ace_types.h"
 
 /**
  * Basic evaluator class, that should accept the basis set and implement the "compute_atom" method using given basis set.

--- a/ML-PACE/ace-evaluator/ace_flatten_basis.cpp
+++ b/ML-PACE/ace-evaluator/ace_flatten_basis.cpp
@@ -28,7 +28,7 @@
 
 // Created by yury on 28.04.2020.
 
-#include "ace_flatten_basis.h"
+#include "ace-evaluator/ace_flatten_basis.h"
 
 ACEFlattenBasisSet::ACEFlattenBasisSet(const ACEFlattenBasisSet &other) {
     _copy_scalar_memory(other);

--- a/ML-PACE/ace-evaluator/ace_flatten_basis.h
+++ b/ML-PACE/ace-evaluator/ace_flatten_basis.h
@@ -31,11 +31,11 @@
 #define ACE_EVALUATOR_ACE_FLATTEN_BASIS_H
 
 
-#include "ace_abstract_basis.h"
-#include "ace_c_basisfunction.h"
-#include "ace_radial.h"
-#include "ace_spherical_cart.h"
-#include "ace_types.h"
+#include "ace-evaluator/ace_abstract_basis.h"
+#include "ace-evaluator/ace_c_basisfunction.h"
+#include "ace-evaluator/ace_radial.h"
+#include "ace-evaluator/ace_spherical_cart.h"
+#include "ace-evaluator/ace_types.h"
 
 /**
  * Basis set with basis function attributes, i.e. \f$ \mathbf{n}, \mathbf{l}, \mathbf{m}\f$, etc.

--- a/ML-PACE/ace-evaluator/ace_radial.cpp
+++ b/ML-PACE/ace-evaluator/ace_radial.cpp
@@ -30,7 +30,7 @@
 #include <functional>
 #include <stdexcept>
 
-#include "ace_radial.h"
+#include "ace-evaluator/ace_radial.h"
 
 #define sqr(x) ((x)*(x))
 const DOUBLE_TYPE pi = 3.14159265358979323846264338327950288419; // pi

--- a/ML-PACE/ace-evaluator/ace_radial.h
+++ b/ML-PACE/ace-evaluator/ace_radial.h
@@ -28,8 +28,8 @@
 #ifndef ACE_RADIAL_FUNCTIONS_H
 #define ACE_RADIAL_FUNCTIONS_H
 
-#include "ace_arraynd.h"
-#include "ace_types.h"
+#include "ace-evaluator/ace_arraynd.h"
+#include "ace-evaluator/ace_types.h"
 #include <functional>
 
 

--- a/ML-PACE/ace-evaluator/ace_recursive.cpp
+++ b/ML-PACE/ace-evaluator/ace_recursive.cpp
@@ -28,10 +28,10 @@
 
 // Created by Christoph Ortner on 20.12.2020
 
-#include "ace_recursive.h"
+#include "ace-evaluator/ace_recursive.h"
 
-#include "ace_abstract_basis.h"
-#include "ace_types.h"
+#include "ace-evaluator/ace_abstract_basis.h"
+#include "ace-evaluator/ace_types.h"
 
 /* ------------------------------------------------------------
  *        ACEDAG Implementation

--- a/ML-PACE/ace-evaluator/ace_recursive.h
+++ b/ML-PACE/ace-evaluator/ace_recursive.h
@@ -31,14 +31,14 @@
 #ifndef ACE_RECURSIVE_H
 #define ACE_RECURSIVE_H
 
-#include "ace_abstract_basis.h"
-#include "ace_arraynd.h"
-#include "ace_array2dlm.h"
-#include "ace_c_basis.h"
-#include "ace_complex.h"
-#include "ace_timing.h"
-#include "ace_types.h"
-#include "ace_evaluator.h"
+#include "ace-evaluator/ace_abstract_basis.h"
+#include "ace-evaluator/ace_arraynd.h"
+#include "ace-evaluator/ace_array2dlm.h"
+#include "ace-evaluator/ace_c_basis.h"
+#include "ace-evaluator/ace_complex.h"
+#include "ace-evaluator/ace_timing.h"
+#include "ace-evaluator/ace_types.h"
+#include "ace-evaluator/ace_evaluator.h"
 
 #include <list>
 #include <utility>

--- a/ML-PACE/ace-evaluator/ace_spherical_cart.cpp
+++ b/ML-PACE/ace-evaluator/ace_spherical_cart.cpp
@@ -29,7 +29,7 @@
 
 #include <cmath>
 
-#include "ace_spherical_cart.h"
+#include "ace-evaluator/ace_spherical_cart.h"
 
 ACECartesianSphericalHarmonics::ACECartesianSphericalHarmonics(LS_TYPE lm) {
     init(lm);

--- a/ML-PACE/ace-evaluator/ace_spherical_cart.h
+++ b/ML-PACE/ace-evaluator/ace_spherical_cart.h
@@ -32,10 +32,10 @@
 
 #include <cmath>
 
-#include "ace_arraynd.h"
-#include "ace_array2dlm.h"
-#include "ace_complex.h"
-#include "ace_types.h"
+#include "ace-evaluator/ace_arraynd.h"
+#include "ace-evaluator/ace_array2dlm.h"
+#include "ace-evaluator/ace_complex.h"
+#include "ace-evaluator/ace_types.h"
 
 
 using namespace std;

--- a/ML-PACE/ace-evaluator/ace_utils.h
+++ b/ML-PACE/ace-evaluator/ace_utils.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <sstream>
 
-#include "ace_types.h"
+#include "ace-evaluator/ace_types.h"
 
 using namespace std;
 

--- a/ML-PACE/ace-evaluator/ships_radial.cpp
+++ b/ML-PACE/ace-evaluator/ships_radial.cpp
@@ -27,7 +27,7 @@
 
 // Created by Christoph Ortner  on 03.06.2020
 
-#include "ships_radial.h"
+#include "ace-evaluator/ships_radial.h"
 
 #include <functional>
 #include <cmath>

--- a/ML-PACE/ace-evaluator/ships_radial.h
+++ b/ML-PACE/ace-evaluator/ships_radial.h
@@ -31,9 +31,9 @@
 #ifndef SHIPs_RADIAL_FUNCTIONS_H
 #define SHIPs_RADIAL_FUNCTIONS_H
 
-#include "ace_arraynd.h"
-#include "ace_types.h"
-#include "ace_radial.h"
+#include "ace-evaluator/ace_arraynd.h"
+#include "ace-evaluator/ace_types.h"
+#include "ace-evaluator/ace_radial.h"
 #include <yaml-cpp/yaml.h>
 
 class SHIPsRadPolyBasis {

--- a/ML-PACE/ace/ace_b_basis.cpp
+++ b/ML-PACE/ace/ace_b_basis.cpp
@@ -1,16 +1,16 @@
 //
 // Created by Yury Lysogorskiy on 16.03.2020.
 //
-#include "ace_b_basis.h"
+#include "ace/ace_b_basis.h"
 
 #include <algorithm>
 #include <sstream>
 
 
-#include "ace_yaml_input.h"
-#include "ace_couplings.h"
-#include "ace_c_basis.h"
-#include "ace_utils.h"
+#include "ace/ace_yaml_input.h"
+#include "ace/ace_couplings.h"
+#include "ace-evaluator/ace_c_basis.h"
+#include "ace-evaluator/ace_utils.h"
 
 void group_basis_functions_by_index(const vector<ACEBBasisFunction> &basis,
                                     Basis_functions_map &basis_functions_map) {

--- a/ML-PACE/ace/ace_b_basis.h
+++ b/ML-PACE/ace/ace_b_basis.h
@@ -12,10 +12,10 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "ace_b_basisfunction.h"
-#include "ace_flatten_basis.h"
-#include "ace_clebsch_gordan.h"
-#include "ace_c_basis.h"
+#include "ace/ace_b_basisfunction.h"
+#include "ace-evaluator/ace_flatten_basis.h"
+#include "ace/ace_clebsch_gordan.h"
+#include "ace-evaluator/ace_c_basis.h"
 
 using namespace std;
 

--- a/ML-PACE/ace/ace_b_basisfunction.cpp
+++ b/ML-PACE/ace/ace_b_basisfunction.cpp
@@ -2,17 +2,17 @@
 // Created by Yury Lysogorskiy on 28.02.20.
 //
 
-#include "ace_b_basisfunction.h"
+#include "ace/ace_b_basisfunction.h"
 
 #include <algorithm>
 #include <cstdio>
 #include <sstream>
 
 
-#include "ace_b_basis.h"
-#include "ace_clebsch_gordan.h"
-#include "ace_couplings.h"
-#include "ace_utils.h"
+#include "ace/ace_b_basis.h"
+#include "ace/ace_clebsch_gordan.h"
+#include "ace/ace_couplings.h"
+#include "ace-evaluator/ace_utils.h"
 
 ACEClebschGordan clebsch_gordan(10);
 

--- a/ML-PACE/ace/ace_b_basisfunction.h
+++ b/ML-PACE/ace/ace_b_basisfunction.h
@@ -14,8 +14,8 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "ace_c_basisfunction.h"
-#include "ace_types.h"
+#include "ace-evaluator/ace_c_basisfunction.h"
+#include "ace-evaluator/ace_types.h"
 
 
 using namespace std;

--- a/ML-PACE/ace/ace_b_evaluator.cpp
+++ b/ML-PACE/ace/ace_b_evaluator.cpp
@@ -2,13 +2,13 @@
 // Created by Yury Lysogorskiy on 31.01.20.
 //
 
-#include "ace_b_evaluator.h"
+#include "ace/ace_b_evaluator.h"
 
-#include "cnpy.h"
+#include "cnpy/cnpy.h"
 
-#include "ace_evaluator.h"
-#include "ace_types.h"
-#include "ace_abstract_basis.h"
+#include "ace-evaluator/ace_evaluator.h"
+#include "ace-evaluator/ace_types.h"
+#include "ace-evaluator/ace_abstract_basis.h"
 
 //================================================================================================================
 

--- a/ML-PACE/ace/ace_b_evaluator.h
+++ b/ML-PACE/ace/ace_b_evaluator.h
@@ -6,14 +6,14 @@
 #define ACE_B_EVALUATOR_H
 
 
-#include "ace_arraynd.h"
-#include "ace_array2dlm.h"
-#include "ace_b_basis.h"
-#include "ace_complex.h"
-#include "ace_timing.h"
-#include "ace_types.h"
-#include "ace_evaluator.h"
-#include "ace_abstract_basis.h"
+#include "ace-evaluator/ace_arraynd.h"
+#include "ace-evaluator/ace_array2dlm.h"
+#include "ace/ace_b_basis.h"
+#include "ace-evaluator/ace_complex.h"
+#include "ace-evaluator/ace_timing.h"
+#include "ace-evaluator/ace_types.h"
+#include "ace-evaluator/ace_evaluator.h"
+#include "ace-evaluator/ace_abstract_basis.h"
 
 class ACEBEvaluator : public ACEEvaluator {
 

--- a/ML-PACE/ace/ace_clebsch_gordan.cpp
+++ b/ML-PACE/ace/ace_clebsch_gordan.cpp
@@ -1,10 +1,10 @@
+#include "ace_clebsch_gordan.h"
+
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
-#include <limits>
-
-#include "ace_clebsch_gordan.h"
 #include <sstream>
+#include "wigner_3nj.hpp"
 
 using namespace std;
 
@@ -70,43 +70,10 @@ The value of lmax
 @returns None
 */
 ACEClebschGordan::ACEClebschGordan(LS_TYPE lm) {
-//    init(lm);
 }
 
 
 void ACEClebschGordan::init(LS_TYPE lm) {
-//    if (lm<lmax)
-//        return;;
-//
-//    lmax = lm;
-//
-//    //calculate the total size required
-//    //eq (12) of Ref. [1] Jour. Mol. Str. THEOCHEM 715 (2005) 177-181
-//    //1 + (l1*(1 + l1)*(-2 + l1*(5 + 3*l1)))/12 + (l2*(1 + l2))/2 + ((1 + l1)*(2 + l1)*(l1 + m1))/2 + m2
-//
-//    // maximum index F1 for columns from eq.(12)
-//    F1max = (lmax * (lmax + 1) * (lmax * (3 * lmax + 5) - 2)) / 12 + (lmax + 1) * (lmax + 2) * (lmax + lmax) / 2 +
-//            (lmax * (lmax + 1)) / 2 + lmax + 1;
-//    F1max = F1max + 1; // for the first element in the last row
-//
-//    // maximum index F2 for rows from eq.(13)
-//    F2max = lmax + 1;
-//    F2max = F2max + 1; // for the first element in the last row
-//
-//    cgcoeff_len = F1max * F2max;
-//    factorial_len = 4 * lmax + 2;
-//#ifdef DEBUG_CLEBSCH
-//    cout<<"F1max="<<F1max<< " F2max="<<F2max<<endl;
-//    cout<<"factorial_len="<<factorial_len<<endl;
-//    cout<<"cgcoeff_len="<<cgcoeff_len<<endl;
-//#endif
-//    fac.init(factorial_len, "fac");
-//
-//    cgcoeff.init(cgcoeff_len, "cgcoeff");
-//    //fill in arrays with 0s, just to be sure for different compiler in same behaviour
-//    fac.fill(0);
-//    cgcoeff.fill(0);
-//    pre_compute();
 }
 
 /**
@@ -128,134 +95,11 @@ Precomputes factorials up to 4*lmax+1 to use in the Racha's formula and other co
 @returns None
 */
 void ACEClebschGordan::pre_compute() {
-//
-//    // the maximum factorial that can be computed is 20! with unsigned long long int
-//    fac(0) = 1; // 0!
-//    fac(1) = 1; // 1!
-//
-//    for (LS_TYPE l = 2; l <= 4 * lmax + 1; l++) {
-//        if (fac(l - 1) * l < (std::numeric_limits<double>::max() - 1)) {
-//            fac(l) = fac(l - 1) * (l);
-//        } else {
-//            stringstream s;
-//            s << "Overflow! lmax = " << lmax << ", l=" << l << "! is too large";
-//            throw invalid_argument(s.str());
-//        }
-//    }
-//
-//    DOUBLE_TYPE cg_value;
-//    int i, j;
-//
-//    for (LS_TYPE j1 = 0; j1 <= lmax; j1++)
-//        for (LS_TYPE j2 = 0; j2 <= j1; j2++)
-//            for (MS_TYPE m1 = -j1; m1 <= j1; m1++)
-//                for (MS_TYPE m2 = 0; m2 <= j2; m2++)
-//                    for (LS_TYPE J = abs(j1 - j2); J <= abs(j1 + j2); J++)
-//                        for (MS_TYPE M = -J; M <= J; M++) {
-//
-//
-//                            if ((M != m1 + m2) || ((j1 + j2 + J) % 2 != 0))
-//                                continue;
-//
-//                            i = compact_cg_get_i_coeff(j1, m1, j2, m2);
-//                            j = compact_cg_get_j_coeff(j1, m1, j2, m2, J);
-//                            cg_value = _compute_cbl(j1, m1, j2, m2, J, M);
-//#ifdef DEBUG_CLEBSCH
-//                            cout << "Cahing: CG("<< j1<<","<< m1<<"),("<<j2<<","<<m2<<"),("<<J<<","<<M<<")="<<cg_value <<endl;
-//                            cout<<"goes to: i="<<i<<" j="<<j<<endl<<endl;
-//#endif
-//                            if (i * F2max + j < cgcoeff_len)
-//                                cgcoeff(i * F2max + j) = cg_value;
-//                            else {
-//                                stringstream s;
-//                                char buf[1024];
-//                                sprintf(buf, "C_L(%d|%d,%d)_M(%d|%d,%d): ", J, j1, j2, M, m1, m2);
-//                                s << buf;
-//                                s << "cgcoeff out ouf range index: i=" << i << ", j=" << j << ", index=i*F2max+j="
-//                                  << i * F2max + j << ", but max_ind = " << cgcoeff_len << endl
-//                                  << "Probably Clebsh-Gordan coefficients were initialized for smaller lmax="<<lmax;
-//
-//                                throw invalid_argument(s.str());
-//                            }
-//                        }
 }
 
 
 double ACEClebschGordan::clebsch_gordan(LS_TYPE j1, MS_TYPE m1, LS_TYPE j2, MS_TYPE m2, LS_TYPE J, MS_TYPE M) const {
     return anotherClebschGordan(j1, m1, j2, m2, J, M);
-//    int i, j;
-//    DOUBLE_TYPE cg_inmem;
-//#ifdef DEBUG_CLEBSCH
-//    double cg_value;
-//#endif
-//
-//    if ((M != m1 + m2) ) { //|| ((j1 + j2 + J) % 2 != 0)
-//#ifdef DEBUG_CLEBSCH
-//        cg_value = 0;
-//        cout << "CG("<< j1<<","<< m1<<"),("<<j2<<","<<m2<<"),("<<J<<","<<M<<")="<<cg_value <<endl<<endl;
-//#endif
-//        return 0;
-//    }
-//    LS_TYPE jmin = abs(j1 - j2);
-//    LS_TYPE jmax = abs(j1 + j2);
-//    if (J > jmax || J < jmin)
-//        return 0;
-//
-//    if (abs(m1) > j1) {
-//        stringstream s;
-//        char buf[1024];
-//        sprintf(buf, "C_L(%d|%d,%d)_M(%d|%d,%d): ", J, j1, j2, M, m1, m2);
-//        s << buf;
-//        s << "Non-sense coefficient C_L: |m1|>l1";
-//        throw invalid_argument(s.str());
-//    }
-//    if (abs(m2) > j2) {
-//        stringstream s;
-//        char buf[1024];
-//        sprintf(buf, "C_L(%d|%d,%d)_M(%d|%d,%d): ", J, j1, j2, M, m1, m2);
-//        s << buf;
-//        s << "Non-sense coefficient: |m2|>l2";
-//        throw invalid_argument(s.str());
-//    }
-//    if (abs(M) > J) {
-//        stringstream s;
-//        char buf[1024];
-//        sprintf(buf, "C_L(%d|%d,%d)_M(%d|%d,%d): ", J, j1, j2, M, m1, m2);
-//        s << buf;
-//        s << "Non-sense coefficient: |M|>L";
-//        throw invalid_argument(s.str());
-//    }
-//
-//    if (j2 > j1)
-//        return clebsch_gordan(j2, m2, j1, m1, J, M);
-//
-//    if (m2 < 0)
-//        return clebsch_gordan(j1, -m1, j2, -m2, J, -M);
-//
-//    i = compact_cg_get_i_coeff(j1, m1, j2, m2);
-//    j = compact_cg_get_j_coeff(j1, m1, j2, m2, J);
-//#ifdef DEBUG_CLEBSCH
-//    cout<<"goes from: i="<<i<<" j="<<j<<endl;
-//#endif
-//    if (i * F2max + j < cgcoeff_len) {
-//        cg_inmem = cgcoeff(i * F2max + j);
-//#ifdef DEBUG_CLEBSCH
-//        cg_value = _compute_cbl(j1, m1, j2, m2, J,M);
-//        if (cg_value != cg_inmem)
-//            cout<<"WARNING!!!"<<endl;
-//        cout << "CG("<< j1<<","<< m1<<"),("<<j2<<","<<m2<<"),("<<J<<","<<M<<")="<<cg_value<<"(actual)"<<cg_inmem <<"(in mem)"<<endl<<endl;
-//#endif
-//        return cg_inmem;
-//    } else {
-//        stringstream s;
-//        char buf[1024];
-//        sprintf(buf, "C_L(%d|%d,%d)_M(%d|%d,%d): ", J, j1, j2, M, m1, m2);
-//        s << buf;
-//        s << "cgcoeff out ouf range index: i=" << i << ", j=" << j << ", index=i*F2max+j=" << i * F2max + j
-//          << ", but max_ind = " << cgcoeff_len << endl;
-//        s << "Probably Clebsh-Gordan coefficients were initialized for smaller lmax="<<lmax;
-//        throw invalid_argument(s.str());
-//    }
 }
 
 

--- a/ML-PACE/ace/ace_clebsch_gordan.cpp
+++ b/ML-PACE/ace/ace_clebsch_gordan.cpp
@@ -1,10 +1,10 @@
-#include "ace_clebsch_gordan.h"
+#include "ace/ace_clebsch_gordan.h"
 
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
-#include "wigner_3nj.hpp"
+#include "wigner/wigner_3nj.hpp"
 
 using namespace std;
 

--- a/ML-PACE/ace/ace_clebsch_gordan.h
+++ b/ML-PACE/ace/ace_clebsch_gordan.h
@@ -4,8 +4,8 @@
 #include <cmath>
 #include <iostream>
 
-#include "ace_types.h"
-#include "ace_arraynd.h"
+#include "ace-evaluator/ace_types.h"
+#include "ace-evaluator/ace_arraynd.h"
 
 using namespace std;
 

--- a/ML-PACE/ace/ace_clebsch_gordan.h
+++ b/ML-PACE/ace/ace_clebsch_gordan.h
@@ -4,8 +4,6 @@
 #include <cmath>
 #include <iostream>
 
-#include "wigner_3nj.hpp"
-
 #include "ace_types.h"
 #include "ace_arraynd.h"
 

--- a/ML-PACE/ace/ace_couplings.cpp
+++ b/ML-PACE/ace/ace_couplings.cpp
@@ -1,8 +1,8 @@
-#include "ace_utils.h"
-#include "ace_b_basisfunction.h"
+#include "ace-evaluator/ace_utils.h"
+#include "ace/ace_b_basisfunction.h"
 #include <algorithm>
 #include <cstdio>
-#include "ace_couplings.h"
+#include "ace/ace_couplings.h"
 
 #include <cmath>
 #include <iostream>

--- a/ML-PACE/ace/ace_couplings.h
+++ b/ML-PACE/ace/ace_couplings.h
@@ -7,10 +7,10 @@
 #include <string>
 #include <sstream>
 
-#include "ace_types.h"
-#include "ace_b_basisfunction.h"
-#include "ace_clebsch_gordan.h"
-#include "ace_c_basisfunction.h"
+#include "ace-evaluator/ace_types.h"
+#include "ace/ace_b_basisfunction.h"
+#include "ace/ace_clebsch_gordan.h"
+#include "ace-evaluator/ace_c_basisfunction.h"
 
 
 struct ms_cg_pair {

--- a/ML-PACE/ace/ace_spherical_polar.cpp
+++ b/ML-PACE/ace/ace_spherical_polar.cpp
@@ -1,7 +1,7 @@
 #include <cmath>
 #include <iostream>
 
-#include "ace_spherical_polar.h"
+#include "ace/ace_spherical_polar.h"
 #include <sstream>
 /**
 Constructor for SHarmonics. Dynamically initialises all the arrays.

--- a/ML-PACE/ace/ace_spherical_polar.h
+++ b/ML-PACE/ace/ace_spherical_polar.h
@@ -3,10 +3,10 @@
 
 #include <cmath>
 
-#include "ace_arraynd.h"
-#include "ace_array2dlm.h"
-#include "ace_complex.h"
-#include "ace_types.h"
+#include "ace-evaluator/ace_arraynd.h"
+#include "ace-evaluator/ace_array2dlm.h"
+#include "ace-evaluator/ace_complex.h"
+#include "ace-evaluator/ace_types.h"
 
 
 using namespace std;

--- a/ML-PACE/ace/ace_yaml_input.cpp
+++ b/ML-PACE/ace/ace_yaml_input.cpp
@@ -1,4 +1,4 @@
-#include "ace_yaml_input.h"
+#include "ace/ace_yaml_input.h"
 
 #include <algorithm>
 #include <iostream>
@@ -7,7 +7,7 @@
 
 #include "yaml-cpp/yaml.h"
 
-#include "ace_couplings.h"
+#include "ace/ace_couplings.h"
 
 using namespace std;
 

--- a/ML-PACE/ace/ace_yaml_input.h
+++ b/ML-PACE/ace/ace_yaml_input.h
@@ -10,8 +10,8 @@ C++ file which would contain the code for reading in an input file
 #include <string>
 #include <vector>
 
-#include "ace_types.h"
-#include "ace_b_basis.h"
+#include "ace-evaluator/ace_types.h"
+#include "ace/ace_b_basis.h"
 
 using namespace std;
 


### PR DESCRIPTION
This pull request changes include statement to have a folder prefix, e.g. `#include "ace_b_basis.h` becomes `#include "ace/ace_b_basis.h` and similarly `#include "ace_c_basis.h" becomes `#include "ace-evaluator/ace_c_basis.h"`.
This way only the include path for the ML-PACE folder is required.

The avoiding of conflicts is more important for third party libraries and their headers. E.g. for `cnpy` and `wigner`. In addition, those include folders are only required for compiling the pace library, thus the CMake command to add the includes is split in two, so that those "local" libraries become PRIVATE (and thus are not exported when compiling the rest of LAMMPS) and only the include for yaml-cpp and ML-PACE are PUBLIC.

Of course this will require equivalent changes in LAMMPS to be able to compile it.

Note: this includes the changes from the v.2022.09.27.fix10Oct tag 