### PR TITLE
Small changes needed for Kokkos and Makefile build

### DIFF
--- a/ML-PACE/ace/ace_b_evaluator.h
+++ b/ML-PACE/ace/ace_b_evaluator.h
@@ -44,9 +44,6 @@ class ACEBEvaluator : public ACEEvaluator {
 
     void init(ACEBBasisSet *basis_set);
 
-    // active sets
-    map<SPECIES_TYPE, Array2D<DOUBLE_TYPE>> A_active_set_inv;
-
     bool is_linear_extrapolation_grade = true;
 
     void resize_projections();
@@ -56,6 +53,9 @@ class ACEBEvaluator : public ACEEvaluator {
     void validate_ASI_shape(const string &element_name, SPECIES_TYPE st, const vector<size_t> &shape);
 
 public:
+
+    // active sets
+    map<SPECIES_TYPE, Array2D<DOUBLE_TYPE>> A_active_set_inv;
 
     ACEBEvaluator() = default;
 

--- a/yaml-cpp/Makefile
+++ b/yaml-cpp/Makefile
@@ -1,0 +1,39 @@
+SHELL = /bin/sh
+
+# ------ FILES ------
+
+SRC = $(wildcard src/*.cpp)
+
+
+# ------ DEFINITIONS ------
+
+LIB = libyaml-cpp.a
+OBJ =   $(SRC:.cpp=.o)
+
+
+# ------ SETTINGS ------
+CXXFLAGS = -O3 -fPIC -Iinclude
+
+ARCHIVE =	ar
+ARCHFLAG =	-rc
+USRLIB =
+SYSLIB =
+
+# ------ MAKE PROCEDURE ------
+
+lib: $(OBJ)
+	$(ARCHIVE) $(ARFLAGS) $(LIB) $(OBJ)
+
+# ------ COMPILE RULES ------
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+# ------ CLEAN ------
+clean: clean-all
+
+clean-all:
+	-rm -f *~ $(OBJ) $(LIB)
+
+clean-build:
+	-rm -f *~ $(OBJ)


### PR DESCRIPTION
- Kokkos PACE needs access to `map<SPECIES_TYPE, Array2D<DOUBLE_TYPE>> A_active_set_inv;`
- The Makefile was removed for yaml-cpp but it is needed to build if not using CMake