### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,3 +49,4 @@ target_include_directories(pace PRIVATE ${CNPY_INCLUDE_PATH} ${WIGNER_INCLUDE_PA
 target_compile_definitions(pace PUBLIC EXTRA_C_PROJECTIONS) # important for B-projections and extrapolation grade calculations
 target_compile_definitions(pace PUBLIC COMPUTE_B_GRAD) # important for gradients of B-projections and ctilde functions
 target_link_libraries(pace PRIVATE yaml-cpp-pace cnpy-static)
+install(TARGETS pace LIBRARY DESTINATION lib)


### PR DESCRIPTION
Add install capability to the library. This helps with code installation approaches that expect dependencies to be installed before they can be used. In particular I want to install LAMMPS using Spack. I want to install the dependencies with Spack also. For this libpace need to be installable which it currently isn't. This fix makes libpace installable without forcing a change to the way libpace is normally integrated into LAMMPS.