### PR TITLE
cmake: improve installation so it can be consumed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/ML-PACE/cnpy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,52 +1,134 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(libpace CXX)
+project(libpace VERSION 20240911 LANGUAGES CXX)
 
-# set policy to silence warnings about ignoring <PackageName>_ROOT but use it
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
-# set policy to silence warnings about missing executable permissions in
-# pythonx.y-config when cross-compiling. review occasionally if it may be set to NEW
-if(POLICY CMP0109)
-    cmake_policy(SET CMP0109 OLD)
-endif()
-
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 ##yaml
-# enforce building libyaml-cpp as static library and turn off optional features
-set(YAML_BUILD_SHARED_LIBS OFF)
-set(YAML_CPP_BUILD_CONTRIB OFF)
-set(YAML_CPP_BUILD_TOOLS OFF)
-add_subdirectory(yaml-cpp build-yaml-cpp)
-set(YAML_CPP_INCLUDE_DIR yaml-cpp/include)
+find_package(yaml-cpp QUIET)
+
+if(NOT yaml-cpp_FOUND)
+    # enforce building libyaml-cpp as static library and turn off optional features
+    set(YAML_BUILD_SHARED_LIBS OFF)
+    set(YAML_CPP_BUILD_CONTRIB OFF)
+    set(YAML_CPP_BUILD_TOOLS OFF)
+    add_subdirectory(yaml-cpp build-yaml-cpp)
+    add_library(yaml-cpp::yaml-cpp ALIAS yaml-cpp-pace)
+
+    install(DIRECTORY yaml-cpp/include/yaml-cpp
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+      FILES_MATCHING
+      PATTERN *.h
+    )
+    set(BUILD_YAML_CPP TRUE)
+else()
+    find_package(yaml-cpp REQUIRED)
+    set(BUILD_YAML_CPP FALSE)
+endif()
 
 ## cnpy
-set(CNPY_PATH cnpy)
-set(CNPY_INCLUDE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
-set(CNPY_SRC ${CNPY_PATH}/cnpy.cpp)
-add_library(cnpy-static STATIC ${CNPY_SRC})
-set_target_properties(cnpy-static PROPERTIES LINKER_LANGUAGE CXX)
+find_package(cnpy QUIET)
+
+if(NOT cnpy_FOUND)
+    add_library(cnpy-static STATIC cnpy/cnpy.cpp)
+    target_include_directories(cnpy-static PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/pace>
+    )
+    set_target_properties(cnpy-static PROPERTIES LINKER_LANGUAGE CXX OUTPUT_NAME cnpy)
+    add_library(cnpy::cnpy ALIAS cnpy-static)
+
+    install(DIRECTORY cnpy
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pace
+      FILES_MATCHING
+      PATTERN *.h
+    )
+    set(BUILD_CNPY TRUE)
+else()
+    find_package(cnpy REQUIRED)
+    set(BUILD_CNPY FALSE)
+endif()
 
 ## winger-cpp
 # this is header-only library
 set(WIGNER_PATH wigner-cpp)
 set(WIGNER_INCLUDE_PATH ${WIGNER_PATH}/include)
 
-# ML-PACE includes
-file(GLOB PACE_INCLUDE_DIR ML-PACE)
+install(DIRECTORY wigner
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pace
+  FILES_MATCHING
+  PATTERN *.hpp
+)
 
 # ML-PACE sources
 file(GLOB PACE_EVALUATOR_SOURCES ML-PACE/ace-evaluator/*.cpp)
 file(GLOB PACE_SOURCES ML-PACE/ace/*.cpp)
-list(FILTER PACE_EVALUATOR_SOURCES EXCLUDE REGEX pair_pace*.cpp)
-list(FILTER PACE_SOURCES EXCLUDE REGEX pair_pace*.cpp)
 
 add_library(pace STATIC ${PACE_EVALUATOR_SOURCES} ${PACE_SOURCES})
-#set_target_properties(pace PROPERTIES CXX_EXTENSIONS ON OUTPUT_NAME lammps_pace${LAMMPS_MACHINE})
-target_include_directories(pace PUBLIC ${PACE_INCLUDE_DIR} ${YAML_CPP_INCLUDE_DIR})
-target_include_directories(pace PRIVATE ${CNPY_INCLUDE_PATH} ${WIGNER_INCLUDE_PATH})
+target_include_directories(pace PRIVATE ${WIGNER_INCLUDE_PATH})
 target_compile_definitions(pace PUBLIC EXTRA_C_PROJECTIONS) # important for B-projections and extrapolation grade calculations
 target_compile_definitions(pace PUBLIC COMPUTE_B_GRAD) # important for gradients of B-projections and ctilde functions
-target_link_libraries(pace PRIVATE yaml-cpp-pace cnpy-static)
-install(TARGETS pace LIBRARY DESTINATION lib)
+target_link_libraries(pace PUBLIC yaml-cpp::yaml-cpp cnpy::cnpy)
+
+set(deps_targets "")
+
+if(BUILD_YAML_CPP)
+    list(APPEND deps_targets yaml-cpp-pace)
+else()
+    target_compile_definitions(pace PUBLIC YAML_PACE=YAML)
+    set_target_properties(pace PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+    )
+endif()
+
+if(BUILD_CNPY)
+    list(APPEND deps_targets cnpy-static)
+else()
+    file(MAKE_DIRECTORY ${PROJECT_SOURCE_DIR}/ML-PACE/cnpy)
+    file(WRITE ${PROJECT_SOURCE_DIR}/ML-PACE/cnpy/cnpy.h "#include <cnpy.h>")
+endif()
+
+
+
+include(GNUInstallDirs)
+
+# ML-PACE includes
+target_include_directories(pace
+PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ML-PACE>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/pace>
+)
+
+install(DIRECTORY ML-PACE/ace ML-PACE/ace-evaluator
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pace
+  FILES_MATCHING
+  PATTERN *.h
+)
+
+install(TARGETS pace ${deps_targets} EXPORT pace_Targets
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(EXPORT pace_Targets FILE pace-targets.cmake
+        NAMESPACE pace:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pace
+)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/pace-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/pace-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pace
+)
+
+write_basic_package_version_file("pace-config-version.cmake"
+                                 VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion)
+
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/pace-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/pace-config-version.cmake"
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findcnpy.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pace)
+
+add_library(pace::pace ALIAS pace)

--- a/cmake/Findcnpy.cmake
+++ b/cmake/Findcnpy.cmake
@@ -1,0 +1,21 @@
+find_path(CNPY_INCLUDE_DIR cnpy.h PATH_SUFFIXES include)
+find_library(CNPY_LIBRARY NAMES cnpy PATH_SUFFIXES lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(cnpy REQUIRED_VARS CNPY_LIBRARY CNPY_INCLUDE_DIR)
+
+if(cnpy_FOUND)
+  set(CNPY_LIBRARIES ${CNPY_LIBRARY})
+  set(CNPY_INCLUDE_DIRS ${CNPY_INCLUDE_DIR})
+
+  mark_as_advanced(CNPY_LIBRARIES CNPY_INCLUDE_DIRS)
+
+  if(NOT TARGET cnpy::cnpy)
+    add_library(cnpy::cnpy UNKNOWN IMPORTED)
+    set_target_properties(cnpy::cnpy PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${CNPY_INCLUDE_DIR}")
+
+    set_property(TARGET cnpy::cnpy APPEND PROPERTY
+        IMPORTED_LOCATION "${CNPY_LIBRARY}")
+  endif()
+endif()

--- a/cmake/pace-config.cmake.in
+++ b/cmake/pace-config.cmake.in
@@ -1,0 +1,17 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+if(NOT @BUILD_YAML_CPP@)
+find_dependency(yaml-cpp REQUIRED)
+endif()
+
+if(NOT @BUILD_CNPY@)
+find_dependency(cnpy REQUIRED)
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/pace-targets.cmake)
+
+check_required_components("pace")


### PR DESCRIPTION
Improves the CMake install for two cases:
- yaml-cpp and cnpy are external and can be found via `find_package()`, (useful if it is already provided by e.g. Spack)
- both libraries are built from this checkout and install the necessary files for using the library